### PR TITLE
🔧 Drop support for EOL Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -48,10 +48,10 @@ jobs:
 
     # FYI: Requires token to continue usage
     # - name: Upload to Codecov
-    #   if: matrix.python-version == 3.8
+    #   if: matrix.python-version == 3.9
     #   uses: codecov/codecov-action@v1
     #   with:
-    #     name: pytests-py3.8
+    #     name: pytests-py3.9
     #     flags: pytests
     #     file: ./coverage.xml
     #     fail_ci_if_error: true
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Installation (deps and package)
       run: |
@@ -83,10 +83,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: install flit
       run: |
         pip install flit~=3.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -48,10 +48,10 @@ jobs:
 
     # FYI: Requires token to continue usage
     # - name: Upload to Codecov
-    #   if: matrix.python-version == 3.7
+    #   if: matrix.python-version == 3.8
     #   uses: codecov/codecov-action@v1
     #   with:
-    #     name: pytests-py3.7
+    #     name: pytests-py3.8
     #     flags: pytests
     #     file: ./coverage.xml
     #     fail_ci_if_error: true
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: '3.8'
 
     - name: Installation (deps and package)
       run: |
@@ -83,10 +83,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: '3.8'
     - name: install flit
       run: |
         pip install flit~=3.0

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tox
 To run the code formatting and style checks:
 
 ```bash
-tox -e py37-pre-commit
+tox -e py311-pre-commit
 ```
 
 or directly
@@ -58,7 +58,7 @@ pre-commit run --all
 To run the pre-commit hook test:
 
 ```bash
-tox -e py37-hook
+tox -e py311-hook
 ```
 
 ## Publish to PyPi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 keywords = "mdformat,markdown,markdown-it"
 
-requires-python=">=3.8"
+requires-python=">=3.9"
 requires=["mdformat>=0.7.5,<0.8.0", "wcwidth>=0.2.13"]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 keywords = "mdformat,markdown,markdown-it"
 
-requires-python=">=3.7.0"
+requires-python=">=3.8"
 requires=["mdformat>=0.7.5,<0.8.0", "wcwidth>=0.2.13"]
 
 [tool.flit.metadata.requires-extra]

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = py{37,311},py{37,311}-hook
+envlist = py{38,39,310,311,312,313}
 isolated_build = True
 
-[testenv:py{37,311}]
+[testenv:py{38,39,310,311,312,313}]
 extras = test
-commands = pytest --cov={envsitepackagesdir}/mdformat_tables {posargs} --ff --nf -vv
+commands = pytest --cov={envsitepackagesdir}/mdformat_tables {posargs}
 
-[testenv:pre-commit]
+[testenv:py{38,39,310,311,312,313}-pre-commit]
 deps = pre-commit
 commands = pre-commit run {posargs}
 
-[testenv:py{37,311}-hook]
+[testenv:py{38,39,310,311,312,313}-hook]
 deps = pre-commit
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = py{38,39,310,311,312,313}
+envlist = py{39,310,311,312,313}
 isolated_build = True
 
-[testenv:py{38,39,310,311,312,313}]
+[testenv:py{39,310,311,312,313}]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_tables {posargs}
 
-[testenv:py{38,39,310,311,312,313}-pre-commit]
+[testenv:py{39,310,311,312,313}-pre-commit]
 deps = pre-commit
 commands = pre-commit run {posargs}
 
-[testenv:py{38,39,310,311,312,313}-hook]
+[testenv:py{39,310,311,312,313}-hook]
 deps = pre-commit
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 


### PR DESCRIPTION
This is required for https://github.com/executablebooks/mdformat-tables/pull/23